### PR TITLE
Fix netboot.xyz nginx port mapping

### DIFF
--- a/netboot_xyz/config.yaml
+++ b/netboot_xyz/config.yaml
@@ -38,8 +38,8 @@ services:
 ports:
   3000/tcp: 3000
   69/udp: 69
-  8080/tcp: 80
+  80/tcp: 8080
 ports_description:
   3000/tcp: Web configuration interface
   69/udp: TFTP Port
-  8080/tcp: NGINX server for hosting assets
+  80/tcp: NGINX server for hosting assets


### PR DESCRIPTION
Fixes https://github.com/HenryHST/hassio-addons/issues/24.

## Summary

Home Assistant add-on ports are declared as `container_port: host_port`. The current mapping `8080/tcp: 80` exposes nginx (which listens on container port 80) as host port 80, which is wrong. The correct mapping is `80/tcp: 8080`, which is also what the underlying `docker-netbootxyz` image expects and what the DOCS reference.

## Effect of the bug

- PXE clients cannot fetch locally cached assets from nginx, so `live_endpoint` overrides in boot.cfg do nothing.
- The webapp's Local Assets tab downloads files that are then unreachable over HTTP.
- Host port 80 is commonly bound by other add-ons (Let's Encrypt, Nginx Proxy Manager), so the bind silently fails.

## Change

Two lines in `netboot_xyz/config.yaml`:

```diff
   3000/tcp: 3000
   69/udp: 69
-  8080/tcp: 80
+  80/tcp: 8080
 ports_description:
   3000/tcp: Web configuration interface
   69/udp: TFTP Port
-  8080/tcp: NGINX server for hosting assets
+  80/tcp: NGINX server for hosting assets
```

## Verification

Reproduced on HAOS 17.3 / supervisor 2026.05.1, aarch64. With this fix applied to a locally installed copy of the add-on, `curl http://<ha-host>:8080/` returns the nginx autoindex of `/assets` (HTTP 200). After reverting, the port is closed again. All other ports (3000 ingress, 69 TFTP) keep working unchanged.